### PR TITLE
Remove index html

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ hexo.extend.generator.register('alias', function(locals){
 
   var template = function(path){
     path = url.parse(path).protocol ? path : config.root + route.format(path);
+    path = path.replace(/index.html$/, "");
 
     return [
       '<!DOCTYPE html>',

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ hexo.extend.generator.register('alias', function(locals){
 
   var template = function(path){
     path = url.parse(path).protocol ? path : config.root + route.format(path);
-    path = path.replace(/index.html$/, "");
+    path = path.replace(/index\.html$/, "");
 
     return [
       '<!DOCTYPE html>',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-alias",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Alias generator for Hexo",
   "main": "index",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-alias",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Alias generator for Hexo",
   "main": "index",
   "repository": {


### PR DESCRIPTION
URLs generated by this module differ from normal Hexo URLs in that they end with "\index.html". This change removes the "index.html" ending to make them consistent.