### PR TITLE
feat: 'redirect' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,29 @@ You could also configure multiple aliases. So in the second example,
 
 - http://yoursite.com/foo/ ⇒ http://yoursite.com/cv/
 - http://yoursite.com/bar/ ⇒ http://yoursite.com/cv/
+
+## Redirect
+
+Available in post and page.
+
+``` diff
+source/cv/index.md
+---
+title: some title
+date: some date
++ redirect: http://target-site.com/
+---
+```
+
+http://yoursite.com/cv/ ⇒ http://target-site.com/
+
+``` diff
+source/_posts/foo.md
+---
+title: foo
+date: 2020-01-02 00:00:00
++ redirect: /2020/03/04/bar/
+---
+```
+
+http://yoursite.com/2020/01/02/foo/ ⇒ http://yoursite.com/2020/03/04/bar/

--- a/index.js
+++ b/index.js
@@ -3,3 +3,4 @@
 'use strict';
 
 hexo.extend.generator.register('alias', require('./lib/generator'));
+hexo.extend.filter.register('after_post_render', require('./lib/redirect'));

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -14,7 +14,7 @@ function aliasGenerator(locals) {
 
     if (Object.prototype.hasOwnProperty.call(templateCache, path)) return templateCache[path];
 
-    const result = templateCache[path] = '<!DOCTYPE html>'
+    const result = '<!DOCTYPE html>'
       + '<html>'
       + '<head>'
         + '<meta charset="utf-8">'
@@ -23,6 +23,8 @@ function aliasGenerator(locals) {
         + '<meta http-equiv="refresh" content="0; url=' + path + '">'
       + '</head>'
       + '</html>';
+
+    templateCache[path] = result;
 
     return result;
   }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { full_url_for } = require('hexo-util');
+
+module.exports = function(data) {
+  const { alias, aliases, redirect } = data;
+  if (redirect && !alias && !aliases) {
+    const target = full_url_for.call(this, redirect);
+    data.layout = '';
+    data.content = '<!DOCTYPE html>'
+    + '<html>'
+    + '<head>'
+      + '<meta charset="utf-8">'
+      + '<title>Redirecting...</title>'
+      + '<link rel="canonical" href="' + target + '">'
+      + '<meta http-equiv="refresh" content="0; url=' + target + '">'
+    + '</head>'
+    + '</html>';
+  }
+  return data;
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^7.1.0",
-    "eslint-config-hexo": "^3.0.0",
+    "eslint-config-hexo": "^4.1.0",
     "hexo": "^4.2.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   ],
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
+  "dependencies": {
+    "hexo-util": "^2.4.0"
+  },
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^7.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -2,172 +2,260 @@
 
 const should = require('chai').should(); // eslint-disable-line
 const Hexo = require('hexo');
+const { full_url_for } = require('hexo-util');
 
 describe('hexo-generator-alias', () => {
-  const hexo = new Hexo(__dirname);
-  const Post = hexo.model('Post');
-  const Page = hexo.model('Page');
-  const generator = require('../lib/generator').bind(hexo);
+  describe('alias', () => {
+    const hexo = new Hexo(__dirname);
+    const Post = hexo.model('Post');
+    const Page = hexo.model('Page');
+    const generator = require('../lib/generator').bind(hexo);
 
-  before(() => hexo.init());
+    before(() => hexo.init());
 
-  beforeEach(() => {
-    hexo.locals.invalidate();
+    beforeEach(() => {
+      hexo.locals.invalidate();
+    });
+
+    it('posts', () => {
+      return Post.insert([
+        // alias - string
+        {
+          source: 'foo',
+          slug: 'foo',
+          alias: 'foo1'
+        },
+        // alias - array
+        {
+          source: 'bar',
+          slug: 'bar',
+          alias: ['bar1', 'bar2', 'bar3']
+        },
+        // aliases - string
+        {
+          source: 'baz',
+          slug: 'baz',
+          aliases: 'baz1'
+        },
+        // aliases - array
+        {
+          source: 'boo',
+          slug: 'boo',
+          aliases: ['boo1', 'boo2', 'boo3']
+        }
+      ]).then(() => {
+        const result = generator(hexo.locals.toObject());
+
+        result.map(item => {
+          return item.path;
+        }).should.have.members(['foo1', 'bar1', 'bar2', 'bar3', 'baz1', 'boo1', 'boo2', 'boo3']);
+      }).finally(() => {
+        return Post.remove({});
+      });
+    });
+
+    // it('posts.aliases - array');
+
+    it('pages', () => {
+      return Page.insert([
+        // alias - string
+        {
+          source: 'foo',
+          path: 'foo',
+          alias: 'foo1'
+        },
+        // alias - array
+        {
+          source: 'bar',
+          path: 'bar',
+          alias: ['bar1', 'bar2', 'bar3']
+        },
+        // aliases - string
+        {
+          source: 'baz',
+          path: 'baz',
+          aliases: 'baz1'
+        },
+        // aliases - array
+        {
+          source: 'boo',
+          path: 'boo',
+          aliases: ['boo1', 'boo2', 'boo3']
+        }
+      ]).then(() => {
+        const result = generator(hexo.locals.toObject());
+
+        result.map(item => {
+          return item.path;
+        }).should.have.members(['foo1', 'bar1', 'bar2', 'bar3', 'baz1', 'boo1', 'boo2', 'boo3']);
+      }).finally(() => {
+        return Page.remove({});
+      });
+    });
+
+    it('config.alias', () => {
+      hexo.config.alias = {
+        'api/index.html': 'api/classes/Hexo.html',
+        'plugins/index.html': 'https://github.com/tommy351/hexo/wiki/Plugins'
+      };
+
+      const result = generator(hexo.locals.toObject());
+
+      result[0].path.should.eql('api/index.html');
+      result[0].data.should.include('api/classes/Hexo.html');
+
+      result[1].path.should.eql('plugins/index.html');
+      result[1].data.should.include('https://github.com/tommy351/hexo/wiki/Plugins');
+
+      hexo.config.alias = null;
+    });
+
+    it('config.aliases', () => {
+      hexo.config.aliases = {
+        'api/index.html': 'api/classes/Hexo.html',
+        'plugins/index.html': 'https://github.com/tommy351/hexo/wiki/Plugins'
+      };
+
+      const result = generator(hexo.locals.toObject());
+
+      result[0].path.should.eql('api/index.html');
+      result[0].data.should.include('/api/classes/Hexo.html');
+
+      result[1].path.should.eql('plugins/index.html');
+      result[1].data.should.include('https://github.com/tommy351/hexo/wiki/Plugins');
+
+      hexo.config.alias = null;
+    });
+
+    it('non-default root', () => {
+      hexo.config.root = '/test/';
+      hexo.config.alias = {
+        'api/index.html': 'api/classes/Hexo.html'
+      };
+
+      const result = generator(hexo.locals.toObject());
+
+      result[0].path.should.eql('api/index.html');
+      result[0].data.should.include(hexo.config.root + 'api/classes/Hexo.html');
+
+      hexo.config.root = '/';
+      hexo.config.alias = null;
+    });
+
+    it('external path', () => {
+      hexo.config.alias = {
+        'http': 'http://hexo.io/',
+        'https': 'https://hexo.io/',
+        'relative': '//hexo.io/',
+        'ftp': 'ftp://hexo.io/'
+      };
+
+      const result = generator(hexo.locals.toObject());
+
+      result[0].data.should.include('http://hexo.io/');
+      result[1].data.should.include('https://hexo.io/');
+      result[2].data.should.include('//hexo.io/');
+      result[3].data.should.include('ftp://hexo.io/');
+
+      hexo.config.alias = null;
+    });
+
+    it('remove index.html suffix', () => {
+      hexo.config.alias = {
+        'test': 'fooo/index.html'
+      };
+
+      const result = generator(hexo.locals.toObject());
+
+      result[0].data.should.include('fooo/');
+      result[0].data.should.not.include('fooo/index.html');
+
+      hexo.config.alias = null;
+    });
   });
 
-  it('posts', () => {
-    return Post.insert([
-      // alias - string
-      {
+  describe('redirect', () => {
+    const hexo = new Hexo(__dirname, { silent: true });
+    const Post = hexo.model('Post');
+    const Page = hexo.model('Page');
+    const r = require('../lib/redirect').bind(hexo);
+
+    before(() => hexo.init());
+
+    it('post', async () => {
+      const target = 'http://bar.com';
+      const post = await Post.insert({
         source: 'foo',
         slug: 'foo',
-        alias: 'foo1'
-      },
-      // alias - array
-      {
-        source: 'bar',
-        slug: 'bar',
-        alias: ['bar1', 'bar2', 'bar3']
-      },
-      // aliases - string
-      {
-        source: 'baz',
-        slug: 'baz',
-        aliases: 'baz1'
-      },
-      // aliases - array
-      {
-        source: 'boo',
-        slug: 'boo',
-        aliases: ['boo1', 'boo2', 'boo3']
-      }
-    ]).then(() => {
-      const result = generator(hexo.locals.toObject());
+        redirect: target
+      });
 
-      result.map(item => {
-        return item.path;
-      }).should.have.members(['foo1', 'bar1', 'bar2', 'bar3', 'baz1', 'boo1', 'boo2', 'boo3']);
-    }).finally(() => {
-      return Post.remove({});
+      const result = r(post);
+      result.content.should.include('<meta http-equiv="refresh" content="0; url=' + target + '">');
+
+      await Post.removeById(post._id);
     });
-  });
 
-  // it('posts.aliases - array');
-
-  it('pages', () => {
-    return Page.insert([
-      // alias - string
-      {
+    it('page', async () => {
+      const target = 'http://bar.com';
+      const page = await Page.insert({
         source: 'foo',
         path: 'foo',
-        alias: 'foo1'
-      },
-      // alias - array
-      {
-        source: 'bar',
-        path: 'bar',
-        alias: ['bar1', 'bar2', 'bar3']
-      },
-      // aliases - string
-      {
-        source: 'baz',
-        path: 'baz',
-        aliases: 'baz1'
-      },
-      // aliases - array
-      {
-        source: 'boo',
-        path: 'boo',
-        aliases: ['boo1', 'boo2', 'boo3']
-      }
-    ]).then(() => {
-      const result = generator(hexo.locals.toObject());
+        redirect: target
+      });
 
-      result.map(item => {
-        return item.path;
-      }).should.have.members(['foo1', 'bar1', 'bar2', 'bar3', 'baz1', 'boo1', 'boo2', 'boo3']);
-    }).finally(() => {
-      return Page.remove({});
+      const result = r(page);
+      result.content.should.include('<meta http-equiv="refresh" content="0; url=' + target + '">');
+
+      await Page.removeById(page._id);
     });
-  });
 
-  it('config.alias', () => {
-    hexo.config.alias = {
-      'api/index.html': 'api/classes/Hexo.html',
-      'plugins/index.html': 'https://github.com/tommy351/hexo/wiki/Plugins'
-    };
+    it('should output absolute url', async () => {
+      const target = '/bar/';
+      const post = await Post.insert({
+        source: 'foo',
+        slug: 'foo',
+        redirect: target
+      });
 
-    const result = generator(hexo.locals.toObject());
+      const result = r(post);
+      result.content.should.include('<meta http-equiv="refresh" content="0; url=' + full_url_for.call(hexo, target) + '">');
 
-    result[0].path.should.eql('api/index.html');
-    result[0].data.should.include('api/classes/Hexo.html');
+      await Post.removeById(post._id);
+    });
 
-    result[1].path.should.eql('plugins/index.html');
-    result[1].data.should.include('https://github.com/tommy351/hexo/wiki/Plugins');
+    it('prioritize alias', async () => {
+      const target = 'http://bar.com';
+      const content = 'lorem';
+      const post = await Post.insert({
+        source: 'foo',
+        slug: 'foo',
+        content,
+        alias: 'foo1',
+        redirect: target
+      });
 
-    hexo.config.alias = null;
-  });
+      const result = r(post);
+      result.content.should.eql(content);
 
-  it('config.aliases', () => {
-    hexo.config.aliases = {
-      'api/index.html': 'api/classes/Hexo.html',
-      'plugins/index.html': 'https://github.com/tommy351/hexo/wiki/Plugins'
-    };
+      await Post.removeById(post._id);
+    });
 
-    const result = generator(hexo.locals.toObject());
+    it('prioritize aliases', async () => {
+      const target = 'http://bar.com';
+      const content = 'lorem';
+      const post = await Post.insert({
+        source: 'foo',
+        slug: 'foo',
+        content,
+        aliases: ['foo1'],
+        redirect: target
+      });
 
-    result[0].path.should.eql('api/index.html');
-    result[0].data.should.include('/api/classes/Hexo.html');
+      const result = r(post);
+      result.content.should.eql(content);
 
-    result[1].path.should.eql('plugins/index.html');
-    result[1].data.should.include('https://github.com/tommy351/hexo/wiki/Plugins');
-
-    hexo.config.alias = null;
-  });
-
-  it('non-default root', () => {
-    hexo.config.root = '/test/';
-    hexo.config.alias = {
-      'api/index.html': 'api/classes/Hexo.html'
-    };
-
-    const result = generator(hexo.locals.toObject());
-
-    result[0].path.should.eql('api/index.html');
-    result[0].data.should.include(hexo.config.root + 'api/classes/Hexo.html');
-
-    hexo.config.root = '/';
-    hexo.config.alias = null;
-  });
-
-  it('external path', () => {
-    hexo.config.alias = {
-      'http': 'http://hexo.io/',
-      'https': 'https://hexo.io/',
-      'relative': '//hexo.io/',
-      'ftp': 'ftp://hexo.io/'
-    };
-
-    const result = generator(hexo.locals.toObject());
-
-    result[0].data.should.include('http://hexo.io/');
-    result[1].data.should.include('https://hexo.io/');
-    result[2].data.should.include('//hexo.io/');
-    result[3].data.should.include('ftp://hexo.io/');
-
-    hexo.config.alias = null;
-  });
-
-  it('remove index.html suffix', () => {
-    hexo.config.alias = {
-      'test': 'fooo/index.html'
-    };
-
-    const result = generator(hexo.locals.toObject());
-
-    result[0].data.should.include('fooo/');
-    result[0].data.should.not.include('fooo/index.html');
-
-    hexo.config.alias = null;
+      await Post.removeById(post._id);
+    });
   });
 });


### PR DESCRIPTION
Inspired by https://github.com/hexojs/hexo/issues/4433

It's basically a reverse of `alias` and it's useful for redirecting a post, especially to external link; `alias` only supports external link in config.

Another advantage is that the post still shows up on index page.

Supports page too.

When an article (mistakenly) specifies both `alias:` and `redirect:`, alias takes precedent.